### PR TITLE
fixes for EasyConfig.update

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -574,8 +574,8 @@ class EasyConfig(object):
 
     def update(self, key, value, allow_duplicate=True):
         """
-        Update a string configuration value with a value (i.e. append to it).
-        NOTE: For dictionaries, 'allow_duplicate' will be ignored.
+        Update an easyconfig parameter with the specified value (i.e. append to it).
+        Note: For dictionary easyconfig parameters, 'allow_duplicate' is ignored (since it's meaningless).
         """
         if isinstance(value, string_type):
             inval = [value]
@@ -583,36 +583,41 @@ class EasyConfig(object):
             inval = value
         else:
             msg = "Can't update configuration value for %s, because the attempted"
-            msg += " update value, '%s', is not a string, list or dictionary."
+            msg += " update value, '%s', is not a string, list, tuple or dictionary."
             raise EasyBuildError(msg, key, value)
 
-        # For dictionaries, input value cannot be a string; must be iterable
-        if isinstance(self[key], dict) and isinstance(value, string_type):
+        # For easyconfig parameters that are dictionaries, input value must also be a dictionary
+        if isinstance(self[key], dict) and not isinstance(value, dict):
             msg = "Can't update configuration value for %s, because the attempted"
-            msg += "update value, '%s', is not iterable (list, tuple, dict)."
-            raise EasyBuildError(msg, key, value)
+            msg += "update value (%s), is not a dictionary (type: %s)."
+            raise EasyBuildError(msg, key, value, type(value))
 
-        # Make copy of current configuration value so we can modify it
-        param_value = self[key]
+        # Grab current parameter value so we can modify it
+        param_value = copy.deepcopy(self[key])
+
         if isinstance(param_value, string_type):
             for item in inval:
                 # re.search: only add value to string if it's not there yet (surrounded by whitespace)
                 if allow_duplicate or (not re.search(r'(^|\s+)%s(\s+|$)' % re.escape(item), param_value)):
                     param_value = param_value + ' %s ' % item
+
         elif isinstance(param_value, (list, tuple)):
+            # make sure we have a list value so we can just append to it
             param_value = list(param_value)
             for item in inval:
                 if allow_duplicate or item not in param_value:
                     param_value.append(item)
-            if isinstance(self[key], tuple):     # Cast back to original type
+            # cast back to tuple if original value was a tuple
+            if isinstance(self[key], tuple):
                 param_value = tuple(param_value)
+
         elif isinstance(param_value, dict):
             param_value.update(inval)
         else:
-            msg = "Can't update configuration value for %s, because it's not a string, list or dictionary."
+            msg = "Can't update configuration value for %s, because it's not a string, list, tuple or dictionary."
             raise EasyBuildError(msg, key)
 
-        # Replace modified value back into configuration, preserving type
+        # Overwrite easyconfig parameter value with updated value, preserving type
         self[key] = param_value
 
     def set_keys(self, params):


### PR DESCRIPTION
@kelseymh this fixes some small issues in https://github.com/easybuilders/easybuild-framework/pull/3356:
* only allow dict value to update dict easyconfig parameter
* take copy of original parameter value rather than using reference to original value
* fix comments/error messages