### PR TITLE
allow single-element list as 'sources' value in exts_list

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -547,12 +547,20 @@ class EasyBlock(object):
 
                     if ext_options.get('nosource', None):
                         exts_sources.append(ext_src)
+
                     elif ext_options.get('sources', None):
                         sources = ext_options['sources']
-                        if isinstance(sources, (list, tuple)):
-                            raise EasyBuildError("'sources' entry to 'exts_list' must be a single dictionary.")
 
-                        src = self.fetch_source(sources, checksums, extension=True)
+                        if isinstance(sources, list):
+                            if len(sources) == 1:
+                                source = sources[0]
+                            else:
+                                error_msg = "'sources' spec for %s in exts_list must be single element list"
+                                raise EasyBuildError(error_msg, ext_name, sources)
+                        else:
+                            source = sources
+
+                        src = self.fetch_source(source, checksums, extension=True)
                         # Copy 'path' entry to 'src' for use with extensions
                         ext_src.update({'src': src['path']})
                         exts_sources.append(ext_src)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1196,8 +1196,48 @@ class ToyBuildTest(EnhancedTestCase):
 
         self.test_toy_build(ec_file=test_ec)
 
-    def test_toy_extension_sources(self):
-        """Test install toy that includes extensions with full sources."""
+    def test_toy_extension_sources_single_item_list(self):
+        """Test install toy that includes extensions with 'sources' spec (as single-item list)."""
+        test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
+        toy_ec_txt = read_file(toy_ec)
+
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+
+        # test use of single-element list in 'sources' with just the filename
+        test_ec_txt = '\n'.join([
+            toy_ec_txt,
+            'exts_list = [',
+            '   ("bar", "0.0", {',
+            '       "sources": ["bar-%(version)s.tar.gz"],',
+            '   }),',
+            ']',
+        ])
+        write_file(test_ec, test_ec_txt)
+        self.test_toy_build(ec_file=test_ec)
+
+    def test_toy_extension_sources_str(self):
+        """Test install toy that includes extensions with 'sources' spec (as string value)."""
+        test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
+        toy_ec_txt = read_file(toy_ec)
+
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+
+        # test use of single-element list in 'sources' with just the filename
+        test_ec_txt = '\n'.join([
+            toy_ec_txt,
+            'exts_list = [',
+            '   ("bar", "0.0", {',
+            '       "sources": "bar-%(version)s.tar.gz",',
+            '   }),',
+            ']',
+        ])
+        write_file(test_ec, test_ec_txt)
+        self.test_toy_build(ec_file=test_ec)
+
+    def test_toy_extension_sources_git_config(self):
+        """Test install toy that includes extensions with 'sources' spec including 'git_config'."""
         test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
         toy_ec_txt = read_file(toy_ec)
@@ -1230,7 +1270,6 @@ class ToyBuildTest(EnhancedTestCase):
             ']',
         ])
         write_file(test_ec, test_ec_txt)
-
         self.test_toy_build(ec_file=test_ec)
 
     def test_toy_module_fulltxt(self):


### PR DESCRIPTION
@kelseymh One more additional minor change for https://github.com/easybuilders/easybuild-framework/pull/3294...

To reduce the differences between the `sources` easyconfig parameter and the `'sources'` spec for an extension, we should also allow single-element lists to be used for the latter, so you can do something like:

```python
exts_list = [
    ('example', '1.0', {
        'sources': [SOURCE_TAR_GZ],
    }),
]
```

For convenience, it also makes sense to allow dropping the `[...]`, since we only support single-source extensions anyway.

Tuple values for sources have a specific meaning already, they shouldn't be used to specify a list of source files. A value like `('example.tar.gz', "tar xvfz %s")` for example used to mean something (but we deprecated the use of that a while ago), so I don't think it's wise to silently treat a tuple value as a list of source files.